### PR TITLE
[Touch Control] Fix layout out of screen

### DIFF
--- a/app/src/main/res/layout/touchcontrol_overlay.xml
+++ b/app/src/main/res/layout/touchcontrol_overlay.xml
@@ -2,6 +2,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:fitsSystemWindows="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@android:color/transparent">


### PR DESCRIPTION
This seems to solve issue ["Touch Controls are cut off"](https://github.com/Waterdish/Shipwright-Android/issues/62)