### PR TITLE
Android: replace gyro popup with Android-paradigm UI

### DIFF
--- a/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
+++ b/soh/soh/Enhancements/controls/SohInputEditorWindow.cpp
@@ -1141,17 +1141,43 @@ void SohInputEditorWindow::DrawAddGyroMappingButton(uint8_t port) {
 
     if (ImGui::BeginPopup(popupId.c_str())) {
         mInputEditorPopupOpen = true;
+        auto gyro = Ship::Context::GetInstance()->GetControlDeck()->GetControllerByPort(port)->GetGyro();
+
+#ifdef __ANDROID__
+        bool hasDeviceGyro = gyro->HasAndroidDeviceGyro();
+        bool hasController = !Ship::Context::GetInstance()
+                                  ->GetControlDeck()
+                                  ->GetConnectedPhysicalDeviceManager()
+                                  ->GetConnectedSDLGamepadsForPort(port)
+                                  .empty();
+
+        if (hasDeviceGyro) {
+            ImGui::Text("Add gyro source:");
+            if (ImGui::Button("Use device gyro")) {
+                if (gyro->SetAndroidDeviceGyroMapping()) {
+                    mInputEditorPopupOpen = false;
+                    ImGui::CloseCurrentPopup();
+                }
+            }
+            if (hasController) {
+                ImGui::Text("Or press any button\nor move any axis\non your controller");
+            }
+        } else if (hasController) {
+            ImGui::Text("Press any button\nor move any axis\non your controller");
+        } else {
+            ImGui::Text("No gyro source found.\nConnect a controller\nor use a device\nwith a gyroscope.");
+        }
+#else
         ImGui::Text("Press any button\nor move any axis\nto add gyro device");
+#endif
+
         if (ImGui::Button("Cancel")) {
             mInputEditorPopupOpen = false;
             ImGui::CloseCurrentPopup();
         }
 
-        if (mMappingInputBlockTimer == INT32_MAX && Ship::Context::GetInstance()
-                                                        ->GetControlDeck()
-                                                        ->GetControllerByPort(port)
-                                                        ->GetGyro()
-                                                        ->SetGyroMappingFromRawPress()) {
+        if (mMappingInputBlockTimer == INT32_MAX &&
+            gyro->SetGyroMappingFromRawPress()) {
             mInputEditorPopupOpen = false;
             ImGui::CloseCurrentPopup();
         }


### PR DESCRIPTION
On Android the old "press any button or move any axis" prompt was broken for the common case of using the device's built-in gyroscope with no external controller attached – the device gyro has no button to press.

DrawAddGyroMappingButton now shows three distinct states on Android:
- Device gyro available: a tappable "Use device gyro" button that creates the mapping immediately, plus optional controller hint.
- Controller connected but no device gyro: retains the existing "press any button / move any axis" flow.
- Neither: a clear message explaining that no gyro source was found.

The per-frame SetGyroMappingFromRawPress() loop is preserved so Bluetooth/USB controllers with or without built-in gyros continue to work via button/axis press as before.

Bumps libultraship submodule to the commit that adds the supporting HasAndroidDeviceGyro / SetAndroidDeviceGyroMapping API.